### PR TITLE
Add README notes about Imagemagick resource limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,33 @@ Adding tiles
 
 The original `image.png` is no longer necessary, however it is recommended to keep it for anyone who would like to download the source of the tileset.
 
+ImageMagick policy limits
+-------------------------
+
+You may find that large images fail to convert, giving one of these messages:
+
+```
+wand.exceptions.ImageError: width or height exceeds limit `' @ error/cache.c/OpenPixelCache/3909
+wand.exceptions.CacheError: cache resources exhausted `' @ error/cache.c/OpenPixelCache/4095
+wand.exceptions.WandError: wand contains no images `MagickWand-1' @ error/magick-image.c/MagickGetImageWidth/6336
+```
+
+These errors are caused by a security policy which has been introduced by ImageMagick to deal with buffer overflow attacks.
+
+To fix this, edit `/etc/ImageMagick-6/policy.xml`:
+
+  * `width or height exceeds limit`: increase `domain="resource" name="width"` and `name="height"` to be greater than the input image.
+  * `wand contains no images`: increase `domain="resource" name="width"` and `name="height"` to be greater than the `tiled size` groupXIV prints out.
+  * `cache resources exhausted`: increase `domain="resource" name="area"` (maximum image cache area in pixels) and `domain="resource" name="disk"` (maximum disk space to use for caching large images).
+
+The following settings seem to work for images up to about 30,000 pixels square, which produced a 32768-pixel tiled square:
+
+  * `width` and `height`: `70KP` (70,000 pixels)
+  * `area`: `128GP` (128 gigapixels)
+  * `disk`: `30GiB` (30 gigabytes)
+
+The command `identify -list resource` can be used to display the current resource limits.
+
 Future improvements
 -------------------
 

--- a/tile_cutter/__main__.py
+++ b/tile_cutter/__main__.py
@@ -53,7 +53,7 @@ for z in range(1, max_zoom + 1):
 
     current_image = 0
     total_images = (image_size // source_size) ** 2
-    start_time = last_report_time = time.clock()
+    start_time = last_report_time = time.perf_counter()
 
     for y in range(0, image_size // source_size):
         for x in range(0, image_size // source_size):
@@ -69,8 +69,8 @@ for z in range(1, max_zoom + 1):
                 tile.save(filename=path)
 
             current_image += 1
-            if time.clock() - last_report_time > 1:
-                last_report_time = time.clock()
+            if time.perf_counter() - last_report_time > 1:
+                last_report_time = time.perf_counter()
                 eta = (last_report_time - start_time) / current_image * \
                         (total_images - current_image)
                 logging.info("completion: %.2f%% (ETA: %dh%dm%ds)",


### PR DESCRIPTION
GroupXIV loads extremely large images, which will usually hit the ImageMagick resource limits.

Add some notes to the README about how these limits can be checked, the errors which appear if they're too low, and how to increase them if needed.